### PR TITLE
refactor(main.py): remove deprecated logger.warn call

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,7 +70,7 @@ def get_state_download_url(workspace):
         logger.info(f'retrieved download_url for: {workspace}')
         return state_download_url
     except KeyError:
-        logger.warn(f'no state file download_url for {workspace}')
+        logger.warning(f'no state file download_url for {workspace}')
         return None
 
 


### PR DESCRIPTION
this likely won't affect us for a while, but might as well clean it up https://github.com/python/cpython/issues/105376